### PR TITLE
feat: TRANSIT モード対応 - 空レスポンス問題の修正と乗り換え案内UI

### DIFF
--- a/backend/app/api/directions.py
+++ b/backend/app/api/directions.py
@@ -3,7 +3,9 @@
 """
 from fastapi import APIRouter, HTTPException
 from app.models.request import RouteRequest
-from app.models.response import RouteResponse, RouteInfo
+from app.models.response import (
+    RouteResponse, RouteInfo, TransitStep, TransitDetails, TransitStop, FareInfo
+)
 from app.services.google_maps import GoogleMapsService
 from datetime import datetime, timedelta
 import logging
@@ -26,12 +28,34 @@ async def calculate_route(request: RouteRequest):
     try:
         maps_service = GoogleMapsService()
 
+        # TRANSITモード用パラメータの準備
+        departure_time_str = None
+        transit_prefs = None
+
+        if request.travel_mode == "TRANSIT":
+            if request.departure_time:
+                departure_time_str = request.departure_time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                )
+            if request.transit_preferences:
+                transit_prefs = {}
+                if request.transit_preferences.routing_preference:
+                    transit_prefs["routingPreference"] = (
+                        request.transit_preferences.routing_preference
+                    )
+                if request.transit_preferences.allowed_travel_modes:
+                    transit_prefs["allowedTravelModes"] = (
+                        request.transit_preferences.allowed_travel_modes
+                    )
+
         # Routes APIで経路を計算
         route_data = await maps_service.compute_route(
             origin=request.origin,
             destination=request.destination,
             travel_mode=request.travel_mode,
-            compute_alternative_routes=request.compute_alternative_routes
+            compute_alternative_routes=request.compute_alternative_routes,
+            departure_time=departure_time_str,
+            transit_preferences=transit_prefs
         )
 
         # ルートが見つからない場合
@@ -61,6 +85,13 @@ async def calculate_route(request: RouteRequest):
         # ポリライン情報を取得
         polyline = main_route.get("polyline", {}).get("encodedPolyline")
 
+        # TRANSIT モードの場合、ステップ詳細と運賃を抽出
+        transit_steps = None
+        fare = None
+        if request.travel_mode == "TRANSIT":
+            transit_steps = _extract_transit_steps(main_route, maps_service)
+            fare = _extract_fare(route_data)
+
         route_info = RouteInfo(
             duration_seconds=duration_seconds,
             duration_text=maps_service.format_duration(duration_seconds),
@@ -68,7 +99,9 @@ async def calculate_route(request: RouteRequest):
             distance_text=maps_service.format_distance(distance_meters),
             polyline=polyline,
             start_location=start_location,
-            end_location=end_location
+            end_location=end_location,
+            transit_steps=transit_steps,
+            fare=fare
         )
 
         # 代替ルートの情報を抽出
@@ -125,6 +158,70 @@ async def calculate_route(request: RouteRequest):
             status_code=500,
             detail="経路計算中にエラーが発生しました。しばらくしてから再度お試しください。"
         )
+
+
+def _extract_transit_steps(route: dict, maps_service: GoogleMapsService) -> list[TransitStep]:
+    """ルートからTRANSITステップ情報を抽出"""
+    steps = []
+    for leg in route.get("legs", []):
+        for step in leg.get("steps", []):
+            step_mode = step.get("travelMode", "WALK")
+            duration_sec = int(step.get("staticDuration", "0s").rstrip("s")) if step.get("staticDuration") else 0
+            distance_m = step.get("distanceMeters", 0)
+
+            transit_details = None
+            raw_td = step.get("transitDetails")
+            if raw_td:
+                # 乗車駅
+                dep_stop_data = raw_td.get("stopDetails", {}).get("departureStop", {})
+                dep_stop = TransitStop(
+                    name=dep_stop_data.get("name", ""),
+                    location=None
+                ) if dep_stop_data.get("name") else None
+
+                # 降車駅
+                arr_stop_data = raw_td.get("stopDetails", {}).get("arrivalStop", {})
+                arr_stop = TransitStop(
+                    name=arr_stop_data.get("name", ""),
+                    location=None
+                ) if arr_stop_data.get("name") else None
+
+                # 路線情報
+                line_info = raw_td.get("transitLine", {})
+                vehicle_info = line_info.get("vehicle", {})
+
+                transit_details = TransitDetails(
+                    departure_stop=dep_stop,
+                    arrival_stop=arr_stop,
+                    departure_time=raw_td.get("stopDetails", {}).get("departureTime"),
+                    arrival_time=raw_td.get("stopDetails", {}).get("arrivalTime"),
+                    line_name=line_info.get("name"),
+                    short_name=line_info.get("nameShort"),
+                    vehicle_type=vehicle_info.get("type"),
+                    num_stops=raw_td.get("stopCount"),
+                )
+
+            steps.append(TransitStep(
+                travel_mode=step_mode,
+                duration_text=maps_service.format_duration(duration_sec) if duration_sec else None,
+                distance_text=maps_service.format_distance(distance_m) if distance_m else None,
+                transit_details=transit_details,
+            ))
+    return steps
+
+
+def _extract_fare(route_data: dict) -> FareInfo | None:
+    """レスポンスから運賃情報を抽出"""
+    routes = route_data.get("routes", [])
+    if not routes:
+        return None
+    fare_data = routes[0].get("travelAdvisory", {}).get("transitFare")
+    if not fare_data:
+        return None
+    return FareInfo(
+        currency_code=fare_data.get("currencyCode", ""),
+        units=fare_data.get("units", "0"),
+    )
 
 
 @router.get("/health")

--- a/backend/app/models/request.py
+++ b/backend/app/models/request.py
@@ -2,8 +2,21 @@
 リクエストモデル
 """
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Optional, List
 from datetime import datetime
+
+
+class TransitPreferences(BaseModel):
+    """TRANSIT モードの設定"""
+
+    routing_preference: Optional[str] = Field(
+        default=None,
+        description="ルーティング設定 (LESS_WALKING, FEWER_TRANSFERS)"
+    )
+    allowed_travel_modes: Optional[List[str]] = Field(
+        default=None,
+        description="許可する交通手段 (BUS, SUBWAY, TRAIN, LIGHT_RAIL, RAIL)"
+    )
 
 
 class RouteRequest(BaseModel):
@@ -26,14 +39,28 @@ class RouteRequest(BaseModel):
         description="到着希望時刻（ISO8601形式）",
         example="2026-02-14T15:00:00"
     )
+    departure_time: Optional[datetime] = Field(
+        default=None,
+        description="出発時刻（ISO8601形式）。TRANSITモードで使用。未指定時は現在時刻",
+        example="2026-02-14T14:00:00"
+    )
+    transit_preferences: Optional[TransitPreferences] = Field(
+        default=None,
+        description="TRANSITモード固有の設定"
+    )
 
     class Config:
         json_schema_extra = {
             "example": {
                 "origin": "東京駅",
                 "destination": "渋谷駅",
-                "travel_mode": "DRIVE",
+                "travel_mode": "TRANSIT",
                 "compute_alternative_routes": False,
-                "desired_arrival_time": "2026-02-14T15:00:00"
+                "desired_arrival_time": "2026-02-14T15:00:00",
+                "departure_time": "2026-02-14T14:00:00",
+                "transit_preferences": {
+                    "routing_preference": "FEWER_TRANSFERS",
+                    "allowed_travel_modes": ["TRAIN", "SUBWAY"]
+                }
             }
         }

--- a/backend/app/models/response.py
+++ b/backend/app/models/response.py
@@ -6,6 +6,42 @@ from typing import Optional, List, Dict, Any
 from datetime import datetime
 
 
+class TransitStop(BaseModel):
+    """乗降駅情報"""
+
+    name: str = Field(..., description="駅名")
+    location: Optional[Dict[str, float]] = Field(None, description="座標")
+
+
+class TransitDetails(BaseModel):
+    """TRANSIT ステップの詳細情報"""
+
+    departure_stop: Optional[TransitStop] = Field(None, description="乗車駅")
+    arrival_stop: Optional[TransitStop] = Field(None, description="降車駅")
+    departure_time: Optional[str] = Field(None, description="出発時刻")
+    arrival_time: Optional[str] = Field(None, description="到着時刻")
+    line_name: Optional[str] = Field(None, description="路線名")
+    short_name: Optional[str] = Field(None, description="路線短縮名")
+    vehicle_type: Optional[str] = Field(None, description="車両タイプ (BUS, SUBWAY, TRAIN 等)")
+    num_stops: Optional[int] = Field(None, description="停車駅数")
+
+
+class TransitStep(BaseModel):
+    """TRANSIT ルートの各ステップ"""
+
+    travel_mode: str = Field(..., description="移動手段 (WALK, TRANSIT)")
+    duration_text: Optional[str] = Field(None, description="所要時間")
+    distance_text: Optional[str] = Field(None, description="距離")
+    transit_details: Optional[TransitDetails] = Field(None, description="乗り換え詳細（TRANSIT時のみ）")
+
+
+class FareInfo(BaseModel):
+    """運賃情報"""
+
+    currency_code: str = Field(..., description="通貨コード (JPY等)")
+    units: str = Field(..., description="金額")
+
+
 class RouteInfo(BaseModel):
     """ルート情報"""
 
@@ -16,6 +52,8 @@ class RouteInfo(BaseModel):
     polyline: Optional[str] = Field(None, description="経路のポリライン（エンコード済み）")
     start_location: Dict[str, float] = Field(..., description="出発地の座標")
     end_location: Dict[str, float] = Field(..., description="目的地の座標")
+    transit_steps: Optional[List[TransitStep]] = Field(None, description="TRANSIT モードの各ステップ")
+    fare: Optional[FareInfo] = Field(None, description="運賃情報")
 
 
 class RouteResponse(BaseModel):

--- a/backend/app/services/google_maps.py
+++ b/backend/app/services/google_maps.py
@@ -3,6 +3,7 @@ Google Maps API統合サービス
 """
 import httpx
 from typing import Dict, List, Optional, Tuple
+from datetime import datetime, timezone
 from app.config import settings
 import logging
 
@@ -51,7 +52,9 @@ class GoogleMapsService:
         origin: str,
         destination: str,
         travel_mode: str = "DRIVE",
-        compute_alternative_routes: bool = False
+        compute_alternative_routes: bool = False,
+        departure_time: Optional[str] = None,
+        transit_preferences: Optional[Dict] = None
     ) -> Dict:
         """
         Routes APIを使用して経路を計算
@@ -76,14 +79,25 @@ class GoogleMapsService:
             logger.error(f"Geocoding error: {e}")
             raise
 
+        # Field Maskの構築（TRANSITモードでは追加フィールドを含める）
+        field_mask_parts = [
+            "routes.distanceMeters",
+            "routes.duration",
+            "routes.polyline.encodedPolyline",
+            "routes.legs",
+        ]
+        if travel_mode == "TRANSIT":
+            field_mask_parts.extend([
+                "routes.legs.steps.transitDetails",
+                "routes.legs.steps.travelMode",
+                "routes.travelAdvisory.transitFare",
+            ])
+
         # Routes APIリクエストヘッダー
         headers = {
             "Content-Type": "application/json",
             "X-Goog-Api-Key": self.api_key,
-            "X-Goog-FieldMask": (
-                "routes.distanceMeters,routes.duration,routes.polyline.encodedPolyline,"
-                "routes.legs"
-            )
+            "X-Goog-FieldMask": ",".join(field_mask_parts)
         }
 
         # リクエストボディ
@@ -108,9 +122,20 @@ class GoogleMapsService:
             "computeAlternativeRoutes": compute_alternative_routes
         }
 
-        # TRANSITモード以外はリアルタイムトラフィック考慮を有効化
-        # TRANSITモードではroutingPreferenceを設定できないため除外
-        if travel_mode != "TRANSIT":
+        # TRANSITモード固有の設定
+        if travel_mode == "TRANSIT":
+            # departureTime: 未指定時は現在時刻をデフォルトで設定
+            if departure_time:
+                payload["departureTime"] = departure_time
+            else:
+                payload["departureTime"] = datetime.now(timezone.utc).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                )
+            # transitPreferences の設定
+            if transit_preferences:
+                payload["transitPreferences"] = transit_preferences
+        else:
+            # TRANSITモード以外はリアルタイムトラフィック考慮を有効化
             payload["routingPreference"] = "TRAFFIC_AWARE"
 
         async with httpx.AsyncClient(timeout=30.0) as client:

--- a/frontend/src/components/Form/RouteSearchForm.tsx
+++ b/frontend/src/components/Form/RouteSearchForm.tsx
@@ -1,7 +1,9 @@
 /**
  * 経路検索フォームコンポーネント
  */
-import { useState, FormEvent } from 'react';
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+import type { TransitPreferences } from '../../types';
 
 interface RouteSearchFormProps {
   onSearch: (data: {
@@ -9,6 +11,8 @@ interface RouteSearchFormProps {
     destination: string;
     travel_mode: string;
     desired_arrival_time?: string;
+    departure_time?: string;
+    transit_preferences?: TransitPreferences;
   }) => void;
   isLoading: boolean;
 }
@@ -18,6 +22,17 @@ export function RouteSearchForm({ onSearch, isLoading }: RouteSearchFormProps) {
   const [destination, setDestination] = useState('');
   const [travelMode, setTravelMode] = useState('DRIVE');
   const [arrivalTime, setArrivalTime] = useState('');
+  const [departureTime, setDepartureTime] = useState('');
+  const [routingPreference, setRoutingPreference] = useState('');
+  const [allowedModes, setAllowedModes] = useState<string[]>([]);
+
+  const isTransit = travelMode === 'TRANSIT';
+
+  const handleModeToggle = (mode: string) => {
+    setAllowedModes((prev) =>
+      prev.includes(mode) ? prev.filter((m) => m !== mode) : [...prev, mode]
+    );
+  };
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -27,13 +42,39 @@ export function RouteSearchForm({ onSearch, isLoading }: RouteSearchFormProps) {
       return;
     }
 
-    onSearch({
+    const searchData: Parameters<typeof onSearch>[0] = {
       origin: origin.trim(),
       destination: destination.trim(),
       travel_mode: travelMode,
       desired_arrival_time: arrivalTime || undefined,
-    });
+    };
+
+    if (isTransit) {
+      if (departureTime) {
+        searchData.departure_time = departureTime;
+      }
+      const prefs: TransitPreferences = {};
+      if (routingPreference) {
+        prefs.routing_preference = routingPreference;
+      }
+      if (allowedModes.length > 0) {
+        prefs.allowed_travel_modes = allowedModes;
+      }
+      if (prefs.routing_preference || prefs.allowed_travel_modes) {
+        searchData.transit_preferences = prefs;
+      }
+    }
+
+    onSearch(searchData);
   };
+
+  const transitModeOptions = [
+    { value: 'BUS', label: 'バス' },
+    { value: 'SUBWAY', label: '地下鉄' },
+    { value: 'TRAIN', label: '電車' },
+    { value: 'LIGHT_RAIL', label: 'ライトレール' },
+    { value: 'RAIL', label: '鉄道全般' },
+  ];
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 p-6 bg-white rounded-lg shadow-md">
@@ -87,6 +128,23 @@ export function RouteSearchForm({ onSearch, isLoading }: RouteSearchFormProps) {
         </select>
       </div>
 
+      {isTransit && (
+        <div>
+          <label htmlFor="departure-time" className="block text-sm font-medium text-gray-700 mb-1">
+            出発時刻（オプション）
+          </label>
+          <input
+            id="departure-time"
+            type="datetime-local"
+            value={departureTime}
+            onChange={(e) => setDepartureTime(e.target.value)}
+            className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            disabled={isLoading}
+          />
+          <p className="text-xs text-gray-500 mt-1">未指定の場合は現在時刻で検索します</p>
+        </div>
+      )}
+
       <div>
         <label htmlFor="arrival-time" className="block text-sm font-medium text-gray-700 mb-1">
           到着希望時刻（オプション）
@@ -100,6 +158,51 @@ export function RouteSearchForm({ onSearch, isLoading }: RouteSearchFormProps) {
           disabled={isLoading}
         />
       </div>
+
+      {isTransit && (
+        <>
+          <div>
+            <label htmlFor="routing-pref" className="block text-sm font-medium text-gray-700 mb-1">
+              ルーティング設定
+            </label>
+            <select
+              id="routing-pref"
+              value={routingPreference}
+              onChange={(e) => setRoutingPreference(e.target.value)}
+              className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              disabled={isLoading}
+            >
+              <option value="">指定なし</option>
+              <option value="LESS_WALKING">徒歩を減らす</option>
+              <option value="FEWER_TRANSFERS">乗り換えを減らす</option>
+            </select>
+          </div>
+
+          <div>
+            <span className="block text-sm font-medium text-gray-700 mb-2">
+              交通手段フィルタ
+            </span>
+            <div className="flex flex-wrap gap-2">
+              {transitModeOptions.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => handleModeToggle(opt.value)}
+                  disabled={isLoading}
+                  className={`px-3 py-1.5 text-sm rounded-full border transition-colors ${
+                    allowedModes.includes(opt.value)
+                      ? 'bg-blue-600 text-white border-blue-600'
+                      : 'bg-white text-gray-700 border-gray-300 hover:border-blue-400'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-gray-500 mt-1">未選択の場合はすべての交通手段を使用</p>
+          </div>
+        </>
+      )}
 
       <button
         type="submit"

--- a/frontend/src/components/Result/RouteInfoCard.tsx
+++ b/frontend/src/components/Result/RouteInfoCard.tsx
@@ -1,10 +1,97 @@
 /**
  * ルート情報表示カード
  */
-import type { RouteResponse } from '../../types';
+import type { RouteResponse, TransitStep } from '../../types';
 
 interface RouteInfoCardProps {
   routeData: RouteResponse;
+}
+
+const getVehicleLabel = (type?: string) => {
+  const labels: Record<string, string> = {
+    BUS: 'バス',
+    SUBWAY: '地下鉄',
+    TRAIN: '電車',
+    LIGHT_RAIL: 'ライトレール',
+    RAIL: '鉄道',
+    HEAVY_RAIL: '鉄道',
+    COMMUTER_TRAIN: '通勤電車',
+    HIGH_SPEED_TRAIN: '新幹線',
+    INTERCITY_BUS: '高速バス',
+    TROLLEYBUS: 'トロリーバス',
+    TRAM: '路面電車',
+    FERRY: 'フェリー',
+  };
+  return type ? labels[type] || type : '';
+};
+
+function TransitStepItem({ step }: { step: TransitStep }) {
+  if (step.travel_mode === 'WALK') {
+    return (
+      <div className="flex items-center gap-3 py-2 px-3 bg-gray-50 rounded">
+        <span className="text-lg">🚶</span>
+        <div className="flex-1">
+          <span className="text-sm text-gray-600">徒歩</span>
+          {step.duration_text && (
+            <span className="text-sm text-gray-500 ml-2">{step.duration_text}</span>
+          )}
+          {step.distance_text && (
+            <span className="text-sm text-gray-500 ml-1">({step.distance_text})</span>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  const td = step.transit_details;
+  if (!td) return null;
+
+  return (
+    <div className="py-3 px-3 bg-blue-50 rounded border border-blue-100">
+      <div className="flex items-center gap-2 mb-1">
+        <span className="text-lg">🚆</span>
+        <span className="font-semibold text-blue-800">
+          {td.line_name || td.short_name || ''}
+        </span>
+        {td.vehicle_type && (
+          <span className="text-xs bg-blue-200 text-blue-800 px-2 py-0.5 rounded-full">
+            {getVehicleLabel(td.vehicle_type)}
+          </span>
+        )}
+      </div>
+      <div className="ml-7 space-y-1 text-sm">
+        {td.departure_stop && (
+          <div className="text-gray-700">
+            <span className="font-medium">{td.departure_stop.name}</span>
+            {td.departure_time && (
+              <span className="text-gray-500 ml-2">
+                {new Date(td.departure_time).toLocaleTimeString('ja-JP', {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </span>
+            )}
+          </div>
+        )}
+        {td.arrival_stop && (
+          <div className="text-gray-700">
+            <span className="font-medium">{td.arrival_stop.name}</span>
+            {td.arrival_time && (
+              <span className="text-gray-500 ml-2">
+                {new Date(td.arrival_time).toLocaleTimeString('ja-JP', {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </span>
+            )}
+          </div>
+        )}
+        {td.num_stops != null && (
+          <span className="text-gray-500">{td.num_stops}駅</span>
+        )}
+      </div>
+    </div>
+  );
 }
 
 export function RouteInfoCard({ routeData }: RouteInfoCardProps) {
@@ -57,6 +144,16 @@ export function RouteInfoCard({ routeData }: RouteInfoCardProps) {
             <span className="font-semibold text-gray-800">{route.distance_text}</span>
           </div>
 
+          {route.fare && (
+            <div className="flex justify-between items-center py-2 border-b border-gray-200">
+              <span className="text-gray-600">運賃</span>
+              <span className="font-semibold text-green-700">
+                {route.fare.currency_code === 'JPY' ? '¥' : route.fare.currency_code}
+                {route.fare.units}
+              </span>
+            </div>
+          )}
+
           {recommended_departure_time && (
             <div className="mt-4 p-4 bg-blue-50 border-l-4 border-blue-500 rounded">
               <p className="text-sm text-gray-600 mb-1">推奨出発時刻</p>
@@ -70,6 +167,17 @@ export function RouteInfoCard({ routeData }: RouteInfoCardProps) {
           )}
         </div>
       </div>
+
+      {route.transit_steps && route.transit_steps.length > 0 && (
+        <div className="p-6 bg-white rounded-lg shadow-md">
+          <h3 className="text-xl font-bold text-gray-800 mb-3">乗り換え案内</h3>
+          <div className="space-y-2">
+            {route.transit_steps.map((step, index) => (
+              <TransitStepItem key={index} step={step} />
+            ))}
+          </div>
+        </div>
+      )}
 
       {routeData.alternative_routes.length > 0 && (
         <div className="p-6 bg-white rounded-lg shadow-md">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2,12 +2,50 @@
  * TypeScript型定義
  */
 
+export interface TransitPreferences {
+  routing_preference?: string;
+  allowed_travel_modes?: string[];
+}
+
 export interface RouteRequest {
   origin: string;
   destination: string;
   travel_mode?: string;
   compute_alternative_routes?: boolean;
   desired_arrival_time?: string;
+  departure_time?: string;
+  transit_preferences?: TransitPreferences;
+}
+
+export interface TransitStop {
+  name: string;
+  location?: {
+    lat: number;
+    lng: number;
+  };
+}
+
+export interface TransitDetails {
+  departure_stop?: TransitStop;
+  arrival_stop?: TransitStop;
+  departure_time?: string;
+  arrival_time?: string;
+  line_name?: string;
+  short_name?: string;
+  vehicle_type?: string;
+  num_stops?: number;
+}
+
+export interface TransitStep {
+  travel_mode: string;
+  duration_text?: string;
+  distance_text?: string;
+  transit_details?: TransitDetails;
+}
+
+export interface FareInfo {
+  currency_code: string;
+  units: string;
 }
 
 export interface RouteInfo {
@@ -24,6 +62,8 @@ export interface RouteInfo {
     lat: number;
     lng: number;
   };
+  transit_steps?: TransitStep[];
+  fare?: FareInfo;
 }
 
 export interface RouteResponse {


### PR DESCRIPTION
## Summary

- Issue #7 (TRANSIT モード空レスポンス問題) の根本原因を修正
- バックエンド: TRANSIT 用 Field Mask 拡張、departureTime 自動設定、transitPreferences 対応、レスポンスモデルに乗り換え詳細・運賃を追加
- フロントエンド: TRANSIT 選択時に出発時刻・ルーティング設定・交通手段フィルタ UI を表示、乗り換え案内（路線名・駅名・時刻）と運賃を表示

## Test plan

- [ ] TRANSIT モードで経路検索し、空レスポンスにならないことを確認
- [ ] 乗り換え案内（路線名・駅名・出発/到着時刻）が表示されることを確認
- [ ] 運賃情報が表示されることを確認
- [ ] 出発時刻未指定時に現在時刻がデフォルトで使われることを確認
- [ ] transitPreferences (LESS_WALKING, FEWER_TRANSFERS) が反映されることを確認
- [ ] 交通手段フィルタ (BUS, SUBWAY, TRAIN 等) が動作することを確認
- [ ] DRIVE, WALK, BICYCLE モードが引き続き正常動作することを確認

https://claude.ai/code/session_01Tgv5t1wNGvJoc4LaM7uNPT